### PR TITLE
fix add "scala>" in REPL

### DIFF
--- a/compendium/modules/w09-inheritance-exercise.tex
+++ b/compendium/modules/w09-inheritance-exercise.tex
@@ -17,18 +17,18 @@
 
 \Task \emph{Gemensam bastyp.} Man vill ofta lägga in objekt av olika typ i samma samling.
 \begin{REPL}
-class Gurka(val vikt: Int)
-class Tomat(val vikt: Int)
-val gurkor = Vector(new Gurka(100), new Gurka(200))
-val grönsaker = Vector(new Gurka(300), new Tomat(42))
+scala> class Gurka(val vikt: Int)
+scala> class Tomat(val vikt: Int)
+scala> val gurkor = Vector(new Gurka(100), new Gurka(200))
+scala> val grönsaker = Vector(new Gurka(300), new Tomat(42))
 \end{REPL}
 \Subtask Om en samling innehåller objekt av flera olika typer försöker kompilatorn härleda den mest specifika typen som objekten har gemensamt. Vad blir det för typ på värdet \code{grönsaker} ovan?
 
 \Subtask Försök ta reda på summan av vikterna enligt nedan. Vad ger andra raden för felmeddelande? Varför?
 
 \begin{REPL}
-gurkor.map(_.vikt).sum
-grönsaker.map(_.vikt).sum
+scala> gurkor.map(_.vikt).sum
+scala> grönsaker.map(_.vikt).sum
 \end{REPL}
 
 \Subtask Vi kan göra så att vi kan komma åt vikten på alla grönsaker genom att ge gurkor och tomater en gemensam bastyp som de olika konkreta grönsakstyperna utvidgar med nyckelordet \code{extends}. Man säger att subtyperna \code{Gurka} och \code{Tomat} \textbf{ärver} egenskaperna hos supertypen \code{Grönsak}.
@@ -36,11 +36,11 @@ grönsaker.map(_.vikt).sum
 Attributet \code{vikt} i traiten \code{Grönsak} nedan initialiseras inte förrän konstruktorerna anropas när vi gör \code{new} på någon av klasserna \code{Gurka} eller \code{Tomat}.
 
 \begin{REPL}
-trait Grönsak { val vikt: Int }
-class Gurka(val vikt: Int) extends Grönsak
-class Tomat(val vikt: Int) extends Grönsak
-val gurkor = Vector(new Gurka(100), new Gurka(200))
-val grönsaker = Vector(new Gurka(300), new Tomat(42))
+scala> trait Grönsak { val vikt: Int }
+scala> class Gurka(val vikt: Int) extends Grönsak
+scala> class Tomat(val vikt: Int) extends Grönsak
+scala> val gurkor = Vector(new Gurka(100), new Gurka(200))
+scala> val grönsaker = Vector(new Gurka(300), new Tomat(42))
 \end{REPL}
 
 \Subtask Vad blir det nu för typ på variabeln \code{grönsaker} ovan?
@@ -50,8 +50,8 @@ val grönsaker = Vector(new Gurka(300), new Tomat(42))
 
 \Subtask En trait liknar en klass, men man kan inte instansiera den och den kan inte ha några parametrar. En typ som inte kan instansieras kallas \textbf{abstrakt} \Eng{abstract}. Vad blir det för felmeddelande om du försöker göra \code{new} på en trait enligt nedan?
 \begin{REPL}
-trait Grönsak { val vikt: Int }
-new Grönsak
+scala> trait Grönsak { val vikt: Int }
+scala> new Grönsak
 \end{REPL}
 
 
@@ -59,7 +59,7 @@ new Grönsak
 
 Vad får \code{anonymGrönsak} nedan för typ och strängrepresenation?
 \begin{REPL}
-val anonymGrönsak = new Grönsak { val vikt = 42 }
+scala> val anonymGrönsak = new Grönsak { val vikt = 42 }
 \end{REPL}
 
 


### PR DESCRIPTION
I think it should say "scala>" before all the lines - it does so in the rest of the compendium at least. Or is there a reason why it shouldn't be scala here?