### PR TITLE
fix typos in ide.tex

### DIFF
--- a/compendium/postchapters/ide.tex
+++ b/compendium/postchapters/ide.tex
@@ -7,7 +7,7 @@
 
 En integrerad utvecklingsmiljö \Eng{integrated development environment, IDE} samlar ett flertal verktyg, inklusive en avancerad \textbf{editor} (se appendix \ref{appendix:edit}), för att skapa, köra och testa program. Det finns flera utvecklingsmiljöer att välja mellan, som kan användas för både Scala och Java.
 
-En IDE ger stöd för \textbf{kodkomplettering} \Eng{code completion} där tillgängliga metoder visas i en lista och resten av ett namn kan fyllas i automatiskt efter att du skrivit de första bokstäverna i namnet. En IDE kan hjälpa dig med formattering och även skapa skelettkod utifrån \textbf{kodmallar} \Eng{code templates}. Med \textbf{felindikering} \Eng{error highlighting} får du understrykning av vissa fel direkt i koden och ibland kan du även få hjälp med förslag på åtgärder för att rätta till enkla fel. Funktioner för \textbf{avlusning} \Eng{debugging} hjälper dig att felsöka medan du kör din kod. Med funktioner för \textbf{omstrukturering} \Eng{refactoring} av kod får du hjälp av editorn i samarbete med kompilatorn att göra omfattande strukturförändringar i många kodfiler samtidigt, t.ex. namnbyten med hänsyn taget till språkets synlighetsregler.  
+En IDE ger stöd för \textbf{kodkomplettering} \Eng{code completion} där tillgängliga metoder visas i en lista och resten av ett namn kan fyllas i automatiskt efter att du skrivit de första bokstäverna i namnet. En IDE kan hjälpa dig med formatering och även skapa skelettkod utifrån \textbf{kodmallar} \Eng{code templates}. Med \textbf{felindikering} \Eng{error highlighting} får du understrykning av vissa fel direkt i koden och ibland kan du även få hjälp med förslag på åtgärder för att rätta till enkla fel. Funktioner för \textbf{avlusning} \Eng{debugging} hjälper dig att felsöka medan du kör din kod. Med funktioner för \textbf{omstrukturering} \Eng{refactoring} av kod får du hjälp av editorn i samarbete med kompilatorn att göra omfattande strukturförändringar i många kodfiler samtidigt, t.ex. namnbyten med hänsyn taget till språkets synlighetsregler.  
 
 Alla dessa avancerade funktioner kan öka produktiviteten avsevärt, men samtidigt tar de tid att lära sig och en IDE kan kräva mycket datorkraft och viss väntetid jämfört med en vanlig, fristående editor. I början kan all funktionalitet upplevas som överväldigande och det kan vara svårt att hitta i alla menyer och inställningar. Ska man bara skriva ett litet, enkelt program, eller göra några mindre ändringar, är det många som föredrar en fristående, snabbstartad kodeditor före en fullfjädrad, tungrodd IDE. Å andra sidan kan en IDE med kodkomplettering vara till stor hjälp när man ska lära sig ett nytt api och experimentera med en okänd kodmassa.
 
@@ -155,7 +155,7 @@ Förutom maxminneshöjningen i filen \texttt{eclipse.ini}, som finns i installat
 \item \EclipsePrefsGeneral 
 \\ Markera \FramedCheckmark{Show Heap Status} så får du se minnesanvändningen i en liten ruta i nederdelen av fönstret, vilket hjälper dig att upptäcka om minnesbegränsningen i filen \texttt{eclipse.ini} är en flaskhals vid stora projekt och många öppna fönster. Klicka sedan \Button{Apply} längst ner.
 
-\item \label{item:scala-perspective} \EclipsePrefsGeneral\MenuArrow{Editors}\MenuArrow{Perspective}  
+\item \label{item:scala-perspective} \EclipsePrefsGeneral\MenuArrow{Editors}\MenuArrow{Perspectives}  
 \\ Markera \textit{Scala} i listan med perspektiv och klicka på knappen 
  \\ \Button{Make default} till höger och sedan på knappen \Button{Apply} längst ner.
 
@@ -168,7 +168,7 @@ Förutom maxminneshöjningen i filen \texttt{eclipse.ini}, som finns i installat
 \item \EclipsePrefsGeneral\MenuArrow{Editors}\MenuArrow{Webbrowser}
 \\ Markera \FramedCheckmark{Use external web browser} för att köra din vanliga webbläsare när du klickar på länkar. Klicka sedan \Button{Apply} längst ner.
   
-\item  \EclipsePrefs\MenuArrow{Scala}\MenuArrow{Compile}
+\item  \EclipsePrefs\MenuArrow{Scala}\MenuArrow{Compiler}
 \\ I fliken \textbf{Standard} markera dessa kryssrutor för att få extra varningar: \\
 \begin{tabular}{l @{}l @{}l}
 \textit{deprecation} & \FramedCheckmark{} & varnar vid användning av föråldrad kod som snart utgår \\
@@ -233,7 +233,7 @@ Efter att du öppnat Eclipse med ScalaIDE i ett tomt workspace och valt Scala-pe
 
 \item Högerklicka igen i \Menu{Package Explorer} och välj \MenuArrow{New}\Menu{Scala Object}, varefter en ny dialogruta visas. 
 
-\item Fyll i namnet \texttt{hi} i fältet \Menu{Project Name} och klicka \Button{Finish}.
+\item Fyll i namnet \texttt{hi} i fältet \Menu{Name} och klicka \Button{Finish}.
 
 \item Du får nu i editorvyn ett kodskelett med \code{object hi}.
 


### PR DESCRIPTION
Fixed typos and changed the names of some menu options to as they were named on my computer - but check that my suggestion is correct anyway!